### PR TITLE
Support commands in the dotfile (#17)

### DIFF
--- a/src/klarenz/const.py
+++ b/src/klarenz/const.py
@@ -191,6 +191,12 @@ PDFVIEW_WAIT = 4
 
 
 DOTFILE = "~/.klarenz"
+VALID_DOTFILE_KEYS = (
+    "ly_version", "ly_language", "pdf_viewer",
+    "ly_bin", "ly_paper_size", "ly_staff_size",
+    "load_ekmelily"
+)
+DOTFILE_CMD_IDENTIFIER = "$"
 
 # default settings for dotfile parameter
 LY_MIN_VERSION = "2.21.0"

--- a/src/klarenz/main.py
+++ b/src/klarenz/main.py
@@ -74,7 +74,7 @@ def proc(score,
         compile_flags = set(LP_OUTPUT_FORMATS.keys()).intersection(non_midi_formats)
         compile_flags = " ".join([LP_OUTPUT_FORMATS[flag] for flag in compile_flags])
         lilypond_popenargs = [lilypond, "-o", "/".join((path_, file_name)), compile_flags, ly_path]
-        print(f"Klarenz {version}")
+        print(f"%%% Klarenz {version} %%%")
         Popen(lilypond_popenargs)
         if view:
             pdf_name = ".".join((file_name, "pdf"))

--- a/src/klarenz/version.py
+++ b/src/klarenz/version.py
@@ -1,1 +1,1 @@
-version = "1.1.0"
+version = "1.2.0"


### PR DESCRIPTION
It is easier to write a shell command in the dotfile the get the value for some programs. With this it is possible to
write e.g. pdf_viewer = $which evince than copy-pasting the path to evince by hand.